### PR TITLE
fix: classify off-curve accounts without on-chain data as PDAs

### DIFF
--- a/20260519_solana_extension_inspector/src/authority/classify.ts
+++ b/20260519_solana_extension_inspector/src/authority/classify.ts
@@ -36,7 +36,10 @@ export function createClassifier(conn: Connection) {
         pubkey,
         exists: false,
         onCurve,
-        classification: "unfunded_eoa",
+        // Off-curve addresses have no valid private key, so they are PDAs regardless
+        // of whether they hold an on-chain account. Only on-curve non-existent addresses
+        // are truly unfunded EOAs (valid keypairs that haven't been funded yet).
+        classification: onCurve ? "unfunded_eoa" : "system_pda",
         owner: null,
         lamports: 0,
         details: {},


### PR DESCRIPTION
Off-curve addresses have no valid private key, so they can never be EOAs regardless of whether they hold an on-chain account. Previously, any address with no on-chain account was labelled `unfunded_eoa`; this fixes the non-existent branch to return `system_pda` for off-curve addresses and `unfunded_eoa` only for on-curve ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)